### PR TITLE
Update devel_branch to dashing

### DIFF
--- a/tracks.yaml
+++ b/tracks.yaml
@@ -13,7 +13,7 @@ tracks:
       -i :{release_inc} --os-name debian --os-not-required
     - git-bloom-generate -y rosrpm --prefix release/:{ros_distro} :{ros_distro} -i
       :{release_inc}
-    devel_branch: master
+    devel_branch: dashing
     last_version: 0.8.4
     name: launch_ros
     patches: null


### PR DESCRIPTION
launch_ros is now released from the `dashing` branch for the rosdistro dashing.